### PR TITLE
Fixed a Datastore.scan bug plus Datastore admin action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ Run the app
 
 `$ python manage.py runserver`
 
-Go to 127.0.0.1:8000/admin and enter credentials you created earlier with `createsuperuser`
+Go to http://127.0.0.1:8000/admin and enter credentials you created earlier with `createsuperuser`
+
+At this stage, it is possible to scan a folder with ISO images (ISOMANAGER > Auto-Update Targets > Add Auto-Update Target). This works better if all the images are already registered in the catalog (see [below](#Example json data for importing an ISO) for its format). Alternative, you can add individual ISO images in ISOMANAGER > Managed Items > Add Managed Item). In that case, you will have to create a Catalog Item for the ISO (Library Item -> '+').
 
 ### The app functionality includes:
+
 - [x] Admin management console (django admin)
 - [ ] Scan repository folder and auto-add ISOs
 - [x] Import ISO images into a catalog using json
@@ -84,7 +87,7 @@ Go to 127.0.0.1:8000/admin and enter credentials you created earlier with `creat
             }
 ```
 
-## Documentation
+## Developer Documentation
 
 ---
 

--- a/isomanager/admin.py
+++ b/isomanager/admin.py
@@ -12,12 +12,20 @@ from .models import CatalogItem, Datastore, ManagedItem, RemoteCatalog, UpdateTa
 
 
 # Register your models here.
+
+@admin.action(description='Scan ISO files')
+def scan_action(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.scan()
+    messages.success(request, 'Scanning ISO files is done.')
+
 @admin.register(Datastore)
 class DatastoreAdmin(admin.ModelAdmin):
     list_display = ('location', 'datastore_type', 'auth_type', 'readonly', 'last_scan', 'created_time', 'updated_time')
     list_filter = ('datastore_type', 'auth_type', 'readonly')
     date_hierarchy = 'created_time'
     change_form_template = "isomanager/admin/change-form.html"
+    actions = [scan_action]
 
     def response_change(self, request, obj):
         if "scan" in request.POST:
@@ -35,7 +43,7 @@ class RemoteCatalog(ImportExportModelAdmin):
     date_hierarchy = 'created_time'
     search_fields = ('catalog_name',)
     formfield_overrides = {
-        JSONField: {'widget': JSONEditorWidget},
+        JSONField: {'widget': JSONEditorWidget(mode='tree')},
     }
     change_form_template = "isomanager/admin/remote-cat-populate-items-form.html"
 
@@ -57,7 +65,7 @@ class CatalogItemAdmin(ImportExportModelAdmin):
     # raw_id_fields = ('os_edition',)
     date_hierarchy = 'created_time'
     formfield_overrides = {
-        JSONField: {'widget': JSONEditorWidget},
+        JSONField: {'widget': JSONEditorWidget(mode='tree')},
     }
 
     class Meta:


### PR DESCRIPTION
Hi @raph!

I took the project for a spin, I was a little confused with the django admin at the beginning so I added some blob in the README to get other people started.

Very nice project, it seems very useful. So far my only feedback is that to add an individual ISO image, most of the fields are required but for individual users most of them are not very sensible (like a gpg signed checksum). Maybe leave them as optional?


**Fixes:**

* There was a typo on catalog_item <-> catalog_time plus some issues with defaults that were stopping the scanning to work unless all elements were in the catalog.
* The last_scan update was also missing.

**Improvements:**

* There is an action for the dropdown menu in the django admin for data stores that allows to scan multiple folders.
* The JSON editor is now open in "tree" mode by default.

Also included some documentation improvements in the README and in the JSON editor.